### PR TITLE
Reworking how stack padding works

### DIFF
--- a/.cursor/rules/doc-comments.mdc
+++ b/.cursor/rules/doc-comments.mdc
@@ -3,16 +3,17 @@ description:
 globs: *.rs
 alwaysApply: false
 ---
-This rule provides a standard for Rust doc comment.
+This rule provides a standard for Rust doc comments.
 
 Doc comments should be formatted with line comments in accordance with the [Rust Style
 Guide](https://doc.rust-lang.org/stable/style-guide/#doc-comments).
 
-All public components should have documentation following the convensions defined in [The RustDoc Book](mdc:https:/doc.rust-lang.org/rustdoc/how-to-write-documentation.html).
+All public components should have documentation following the conventions defined in [The RustDoc
+Book](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html).
 
 Documentation for functions should always start with a short summary that describes what the
 function does. Additional exposition is usually not necessary unless the function has preconditions
-that may lead to a error result or panic.
+that may lead to an erroneous result or panic.
 
 For functions that recognize a grammar production, the production is a sufficient comment.
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
     "rust-analyzer.debug.engine": "vadimcn.vscode-lldb",
     "rust-analyzer.lens.debug.enable": true,
     "rust-analyzer.lens.enable": true,
-    "rust-analyzer.lens.run.enable": true
+    "rust-analyzer.lens.run.enable": true,
+    "cSpell.words": [
+        "concatenative"
+    ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 name = "cel-parser"
 version = "0.1.0"
 dependencies = [
+ "litrs",
  "owo-colors",
  "proc-macro2",
  "quote",
@@ -33,14 +34,13 @@ dependencies = [
  "cel-parser",
  "proc-macro2",
  "quote",
- "syn",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "is-terminal"
@@ -61,15 +61,24 @@ checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "owo-colors"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 dependencies = [
  "supports-color 2.1.0",
  "supports-color 3.0.2",
@@ -110,17 +119,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
 dependencies = [
  "is_ci",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
 ]
 
 [[package]]

--- a/cel-parser/Cargo.toml
+++ b/cel-parser/Cargo.toml
@@ -8,4 +8,5 @@ license = "MIT"
 [dependencies]
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 quote = "1.0"
-owo-colors = { version = "4.0", features = ["supports-colors"] }
+owo-colors = { version = "4.2", features = ["supports-colors"] }
+litrs = "0.4.1"

--- a/cel-parser/src/lib.rs
+++ b/cel-parser/src/lib.rs
@@ -84,7 +84,7 @@ impl<I: Iterator<Item = TokenTree> + Clone> CELParser<I> {
                                     if let Some(TokenTree::Literal(lit)) = group_tokens.next() {
                                         // Clean extraction using litrs
                                         if let Ok(string_lit) = StringLit::try_from(lit) {
-                                            return Some(string_lit.value());
+                                            return Some(string_lit.value().to_string());
                                         }
                                     }
                                 }
@@ -484,14 +484,14 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn test_simple_expression() {
+    fn simple_expression() {
         let input = TokenStream::from_str("10").unwrap();
         let mut parser = CELParser::new(input.into_iter());
         assert!(parser.is_expression());
     }
 
     #[test]
-    fn test_incomplete_expression() {
+    fn incomplete_expression() {
         let input = TokenStream::from_str("10 + 25 25").unwrap();
         let mut parser = CELParser::new(input.into_iter());
         assert!(!parser.is_expression());
@@ -502,70 +502,70 @@ mod tests {
     }
 
     #[test]
-    fn test_arithmetic_expression() {
+    fn arithmetic_expression() {
         let input = TokenStream::from_str("10 + 20 * 30").unwrap();
         let mut parser = CELParser::new(input.into_iter());
         assert!(parser.is_expression());
     }
 
     #[test]
-    fn test_parenthesized_expression() {
+    fn parenthesized_expression() {
         let input = TokenStream::from_str("(10 + 20) * 30").unwrap();
         let mut parser = CELParser::new(input.into_iter());
         assert!(parser.is_expression());
     }
 
     #[test]
-    fn test_complex_expression() {
+    fn complex_expression() {
         let input = TokenStream::from_str("10 + 20 * (30 - 5) / 2").unwrap();
         let mut parser = CELParser::new(input.into_iter());
         assert!(parser.is_expression());
     }
 
     #[test]
-    fn test_logical_expression() {
+    fn logical_expression() {
         let input = TokenStream::from_str("a && b || c").unwrap();
         let mut parser = CELParser::new(input.into_iter());
         assert!(parser.is_expression());
     }
 
     #[test]
-    fn test_comparison_expression() {
+    fn comparison_expression() {
         let input = TokenStream::from_str("a == b && c > d").unwrap();
         let mut parser = CELParser::new(input.into_iter());
         assert!(parser.is_expression());
     }
 
     #[test]
-    fn test_bitwise_expression() {
+    fn bitwise_expression() {
         let input = TokenStream::from_str("a | b & c ^ d").unwrap();
         let mut parser = CELParser::new(input.into_iter());
         assert!(parser.is_expression());
     }
 
     #[test]
-    fn test_shift_expression() {
+    fn shift_expression() {
         let input = TokenStream::from_str("a << 2 + b >> 1").unwrap();
         let mut parser = CELParser::new(input.into_iter());
         assert!(parser.is_expression());
     }
 
     #[test]
-    fn test_unary_expression() {
+    fn unary_expression() {
         let input = TokenStream::from_str("-a + !b").unwrap();
         let mut parser = CELParser::new(input.into_iter());
         assert!(parser.is_expression());
     }
 
     #[test]
-    fn test_chained_unary_expression() {
+    fn chained_unary_expression() {
         let input = TokenStream::from_str("!!a + --b").unwrap();
         let mut parser = CELParser::new(input.into_iter());
         assert!(parser.is_expression());
     }
 
     #[test]
-    fn test_invalid_expression() {
+    fn invalid_expression() {
         let input = TokenStream::from_str("+").unwrap();
         let mut parser = CELParser::new(input.into_iter());
         assert!(!parser.is_expression());
@@ -601,7 +601,7 @@ mod tests {
     }
 
     #[test]
-    fn test_error_formatting() {
+    fn error_formatting() {
         let source = "10 + 20 30"; // Missing operator between 20 and 30
         let input = TokenStream::from_str(source).unwrap();
         let mut parser = CELParser::new(input.into_iter());
@@ -627,7 +627,7 @@ mod tests {
     }
 
     #[test]
-    fn test_error_formatting_with_line_offset() {
+    fn error_formatting_with_line_offset() {
         let source = "a + b c"; // Missing operator between b and c
         let input = TokenStream::from_str(source).unwrap();
         let mut parser = CELParser::new(input.into_iter());

--- a/cel-rs-macros/Cargo.toml
+++ b/cel-rs-macros/Cargo.toml
@@ -9,7 +9,6 @@ license = "MIT"
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 cel-parser = { path = "../cel-parser" } 

--- a/cel-rs-macros/src/lib.rs
+++ b/cel-rs-macros/src/lib.rs
@@ -4,42 +4,11 @@ use proc_macro2::TokenStream;
 
 /// Validates that the input contains a valid CEL expression.
 ///
-/// For our arithmetic expression grammar:
-/// ```text
-/// expr = term {("+" | "-") term}.
-/// term = factor {("*" | "/") factor}.
-/// factor = NUMBER | IDENTIFIER | "(" expr ")".
-/// ```
-///
-/// Where:
-/// - NUMBER is any numeric literal
-/// - IDENTIFIER is any valid Rust identifier
-/// - Operators have standard precedence: * and / bind tighter than + and -
-/// - Parentheses can be used to override precedence
-///
-/// # Example
-///
 /// ```rust
 /// use cel_rs_macros::expression;
 /// expression! {
-///     54 + 25 * (11 + 6 *  6)
+///     54 + 25 * (11 + 6 * 6)
 /// };
-/// ```
-///
-/// Will be parsed as:
-/// ```text
-/// factor: 54
-/// term: factor
-/// factor: 25
-/// factor: 11
-/// term: factor
-/// factor: 6
-/// factor: 6
-/// term: factor * factor
-/// expr: term + term
-/// factor: ( expr )
-/// term: factor * factor
-/// expr: term + term
 /// ```
 #[proc_macro]
 pub fn expression(input: ProcMacroTokenStream) -> ProcMacroTokenStream {

--- a/cel-rs-macros/src/lib.rs
+++ b/cel-rs-macros/src/lib.rs
@@ -62,21 +62,21 @@ pub fn expression(input: ProcMacroTokenStream) -> ProcMacroTokenStream {
 /// ```
 #[proc_macro]
 pub fn print_tokens(input: ProcMacroTokenStream) -> ProcMacroTokenStream {
-    println!("{}", input);
+    println!("{input}");
     let input = TokenStream::from(input);
     for e in input {
         match e {
             proc_macro2::TokenTree::Punct(punct) => {
-                println!("punct: {:?}", punct);
+                println!("punct: {punct:?}");
             }
             proc_macro2::TokenTree::Ident(ident) => {
-                println!("ident: {:?}", ident);
+                println!("ident: {ident:?}");
             }
             proc_macro2::TokenTree::Group(group) => {
-                println!("group: {:?}", group);
+                println!("group: {group:?}");
             }
             proc_macro2::TokenTree::Literal(lit) => {
-                println!("literal: {:?}", lit);
+                println!("literal: {lit:?}");
             }
         }
     }

--- a/notes.txt
+++ b/notes.txt
@@ -14,7 +14,6 @@ cargo clippy --workspace
 ```
 
 Figure out if the call operators should be able to reuse the same stack.
-Move HEAD_PADDING trait to separate trait for C Lists
 Rename TupeTraits to something meaningful
 Need to implement adding a segment to a segment - accumulate base alignments - can you add an incomplete segment?
 

--- a/src/c_stack_list.rs
+++ b/src/c_stack_list.rs
@@ -20,8 +20,8 @@
 //! use cel_rs::*;
 //! use typenum::*;
 //!
-//! let list = (1, 2.5, 3, 4, "world", "Hello").into_cstack_list();
-//! assert_eq!(list[..U5::new()][U2::new()..], (3, 4, "world").into_cstack_list());
+//! let list = (1, 2.5, 3, 4, "world", "Hello").into_c_stack_list();
+//! assert_eq!(list[..U5::new()][U2::new()..], (3, 4, "world").into_c_stack_list());
 //! ```
 //!
 //! Indexing out of bounds will result in a compile error.
@@ -30,7 +30,7 @@
 //! use cel_rs::c_stack_list::*;
 //! use typenum::*;
 //!
-//! let list = (1, 2.5, 3, 4, "world", "Hello").into_cstack_list()[U6::new()];
+//! let list = (1, 2.5, 3, 4, "world", "Hello").into_c_stack_list()[U6::new()];
 //! ```
 use std::mem::offset_of;
 use std::ops::{Index, RangeFrom, RangeTo, RangeToInclusive, Sub};
@@ -47,21 +47,32 @@ use crate::list_traits::{
 /// does not change the memory layout of prior items.
 #[repr(C)]
 #[derive(Clone)]
-pub struct CStackList<H, T>(pub T, pub H);
+pub struct CStackList<H, T: CStackListMemoryLayout>(pub T, pub H);
 
-/* pub trait HeadPadding: List {
-    const _HEAD_PADDING: usize;
+/// A trait describing the memory layout of a [`CStackList`].
+pub trait CStackListMemoryLayout {
+    /// The offset to the _end_ of the head element.
+    const HEAD_LIMIT: usize;
+    /// Whether the head element is padded to the next alignment boundary.
+    const HEAD_PADDED: bool;
 }
 
-impl<T: List> HeadPadding for CNil<T> {
-    const _HEAD_PADDING: usize = 0;
+impl<H: 'static, T: CStackListMemoryLayout> CStackListMemoryLayout for CStackList<H, T> {
+    const HEAD_LIMIT: usize = offset_of!(Self, 1) + size_of::<H>();
+    const HEAD_PADDED: bool = offset_of!(Self, 1) != T::HEAD_LIMIT;
 }
 
-impl<H: 'static, T: HeadPadding> HeadPadding for CStackList<H, T> {
-    const _HEAD_PADDING: usize = offset_of!(Self, 1) - size_of::<Self::Tail>();
-} */
+impl<T: CStackListMemoryLayout> CStackListMemoryLayout for CNil<T> {
+    const HEAD_LIMIT: usize = T::HEAD_LIMIT;
+    const HEAD_PADDED: bool = T::HEAD_PADDED;
+}
 
-impl<H: 'static, T: List> List for CStackList<H, T> {
+impl CStackListMemoryLayout for () {
+    const HEAD_LIMIT: usize = 0;
+    const HEAD_PADDED: bool = false;
+}
+
+impl<H: 'static, T: List + CStackListMemoryLayout> List for CStackList<H, T> {
     type Empty = CNil<()>;
     fn empty() -> Self::Empty {
         CNil(())
@@ -76,8 +87,6 @@ impl<H: 'static, T: List> List for CStackList<H, T> {
     fn tail(&self) -> &Self::Tail {
         &self.0
     }
-
-    const HEAD_PADDING: usize = offset_of!(Self, 1) - size_of::<Self::Tail>();
 
     type Push<U: 'static> = CStackList<U, Self>;
     fn push<U: 'static>(self, item: U) -> Self::Push<U> {
@@ -97,24 +106,25 @@ impl<H: 'static, T: List> List for CStackList<H, T> {
 
 pub trait IntoCStackList {
     type Output: List;
-    fn into_cstack_list(self) -> Self::Output;
+    fn into_c_stack_list(self) -> Self::Output;
 }
 
 impl<T: IntoList> IntoCStackList for T {
     type Output = T::Output<CNil<()>>;
-    fn into_cstack_list(self) -> Self::Output {
+    fn into_c_stack_list(self) -> Self::Output {
         self.into_list()
     }
 }
 
-impl<H: 'static, T: List> ListIndex<RangeFrom<U0>> for CStackList<H, T> {
+impl<H: 'static, T: List + CStackListMemoryLayout> ListIndex<RangeFrom<U0>> for CStackList<H, T> {
     type Output = CStackList<H, T>;
     fn index(&self, _index: RangeFrom<U0>) -> &Self::Output {
         self
     }
 }
 
-impl<H: 'static, T: List, U: Unsigned, B: Bit> ListIndex<RangeFrom<UInt<U, B>>> for CStackList<H, T>
+impl<H: 'static, T: List + CStackListMemoryLayout, U: Unsigned, B: Bit>
+    ListIndex<RangeFrom<UInt<U, B>>> for CStackList<H, T>
 where
     T: ListIndex<RangeFrom<Sub1<UInt<U, B>>>>,
     UInt<U, B>: Sub<B1>,
@@ -125,7 +135,7 @@ where
     }
 }
 
-impl<H: 'static, T: List> ListIndex<RangeTo<U0>> for CStackList<H, T> {
+impl<H: 'static, T: List + CStackListMemoryLayout> ListIndex<RangeTo<U0>> for CStackList<H, T> {
     type Output = CNil<CStackList<H, T>>;
     fn index(&self, _index: RangeTo<U0>) -> &Self::Output {
         unsafe { &*ptr::from_ref(self).cast::<Self::Output>() }
@@ -134,7 +144,8 @@ impl<H: 'static, T: List> ListIndex<RangeTo<U0>> for CStackList<H, T> {
 
 type TailRangeTo<T, U, B> = <T as ListIndex<RangeTo<Sub1<UInt<U, B>>>>>::Output;
 
-impl<H: 'static, T: List, U: Unsigned, B: Bit> ListIndex<RangeTo<UInt<U, B>>> for CStackList<H, T>
+impl<H: 'static, T: List + CStackListMemoryLayout, U: Unsigned, B: Bit>
+    ListIndex<RangeTo<UInt<U, B>>> for CStackList<H, T>
 where
     T: ListIndex<RangeTo<Sub1<UInt<U, B>>>>,
     TailRangeTo<T, U, B>: List,
@@ -146,7 +157,9 @@ where
     }
 }
 
-impl<H: 'static, T: List> ListIndex<RangeToInclusive<U0>> for CStackList<H, T> {
+impl<H: 'static, T: List + CStackListMemoryLayout> ListIndex<RangeToInclusive<U0>>
+    for CStackList<H, T>
+{
     type Output = CStackList<H, CNil<T>>;
     fn index(&self, _index: RangeToInclusive<U0>) -> &Self::Output {
         unsafe { &*ptr::from_ref(self).cast::<Self::Output>() }
@@ -155,8 +168,8 @@ impl<H: 'static, T: List> ListIndex<RangeToInclusive<U0>> for CStackList<H, T> {
 
 type TailRangeToInclusive<T, U, B> = <T as ListIndex<RangeToInclusive<Sub1<UInt<U, B>>>>>::Output;
 
-impl<H: 'static, T: List, U: Unsigned, B: Bit> ListIndex<RangeToInclusive<UInt<U, B>>>
-    for CStackList<H, T>
+impl<H: 'static, T: List + CStackListMemoryLayout, U: Unsigned, B: Bit>
+    ListIndex<RangeToInclusive<UInt<U, B>>> for CStackList<H, T>
 where
     T: ListIndex<RangeToInclusive<Sub1<UInt<U, B>>>>,
     TailRangeToInclusive<T, U, B>: List,
@@ -168,14 +181,15 @@ where
     }
 }
 
-impl<H: 'static, T: List> ListIndex<U0> for CStackList<H, T> {
+impl<H: 'static, T: List + CStackListMemoryLayout> ListIndex<U0> for CStackList<H, T> {
     type Output = H;
     fn index(&self, _index: U0) -> &Self::Output {
         self.head()
     }
 }
 
-impl<H: 'static, T: List, U: Unsigned, B: Bit> ListIndex<UInt<U, B>> for CStackList<H, T>
+impl<H: 'static, T: List + CStackListMemoryLayout, U: Unsigned, B: Bit> ListIndex<UInt<U, B>>
+    for CStackList<H, T>
 where
     T: ListIndex<Sub1<UInt<U, B>>>,
     UInt<U, B>: Sub<B1>,
@@ -187,7 +201,7 @@ where
 }
 
 // Implement Index in terms of ListIndex for CStackList
-impl<H: 'static, T: List, Idx> Index<Idx> for CStackList<H, T>
+impl<H: 'static, T: List + CStackListMemoryLayout, Idx> Index<Idx> for CStackList<H, T>
 where
     Self: ListIndex<Idx>,
     <Self as ListIndex<Idx>>::Output: Sized,
@@ -203,13 +217,13 @@ trait DebugHelper {
     fn fmt_helper(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;
 }
 
-impl<T> DebugHelper for CNil<T> {
+impl<T: CStackListMemoryLayout> DebugHelper for CNil<T> {
     fn fmt_helper(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, ")")
     }
 }
 
-impl<H: 'static, T: List> DebugHelper for CStackList<H, T>
+impl<H: 'static, T: List + CStackListMemoryLayout> DebugHelper for CStackList<H, T>
 where
     H: fmt::Debug,
     T: DebugHelper,
@@ -220,13 +234,13 @@ where
     }
 }
 
-impl<T> fmt::Debug for CNil<T> {
+impl<T: CStackListMemoryLayout> fmt::Debug for CNil<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "()")
     }
 }
 
-impl<H: 'static, T: List> fmt::Debug for CStackList<H, T>
+impl<H: 'static, T: List + CStackListMemoryLayout> fmt::Debug for CStackList<H, T>
 where
     H: fmt::Debug,
     T: DebugHelper,
@@ -237,13 +251,14 @@ where
     }
 }
 
-impl<T: List, O: List> std::cmp::PartialEq<O> for CNil<T> {
+impl<T: List + CStackListMemoryLayout, O: List> std::cmp::PartialEq<O> for CNil<T> {
     fn eq(&self, other: &O) -> bool {
         other.is_empty()
     }
 }
 
-impl<H: 'static, T: List, O: List> std::cmp::PartialEq<O> for CStackList<H, T>
+impl<H: 'static, T: List + CStackListMemoryLayout, O: List> std::cmp::PartialEq<O>
+    for CStackList<H, T>
 where
     H: PartialEq<O::Head>,
     T: PartialEq<O::Tail>,
@@ -254,9 +269,9 @@ where
 }
 
 #[repr(C)]
-pub struct CNil<T>(T);
+pub struct CNil<T: CStackListMemoryLayout>(T);
 
-impl<T> EmptyList for CNil<T> {
+impl<T: CStackListMemoryLayout> EmptyList for CNil<T> {
     type PushFirst<U: 'static> = CStackList<U, CNil<T>>;
     fn push_first<U: 'static>(self, item: U) -> Self::PushFirst<U> {
         CStackList(self, item)
@@ -268,14 +283,14 @@ impl<T> EmptyList for CNil<T> {
     }
 }
 
-impl<T, P: ListTypeProperty> ListTypeIteratorAdvance<P> for CNil<T> {
+impl<T: CStackListMemoryLayout, P: ListTypeProperty> ListTypeIteratorAdvance<P> for CNil<T> {
     fn advancer<R: List>(_iter: &mut ListTypeIterator<R, P>) -> Option<P::Output> {
         None
     }
 }
 
-impl<P: ListTypeProperty, H: 'static, T: ListTypeIteratorAdvance<P>> ListTypeIteratorAdvance<P>
-    for CStackList<H, T>
+impl<P: ListTypeProperty, H: 'static, T: ListTypeIteratorAdvance<P> + CStackListMemoryLayout>
+    ListTypeIteratorAdvance<P> for CStackList<H, T>
 {
     fn advancer<R: List>(iter: &mut ListTypeIterator<R, P>) -> Option<P::Output> {
         iter.advance = T::advancer::<R>;
@@ -291,8 +306,8 @@ mod tests {
 
     use super::*;
     #[test]
-    fn into_cstack_list() {
-        let list = (1, 2.5, 3, 4, "world", "Hello").into_cstack_list();
+    fn into_c_stack_list() {
+        let list = (1, 2.5, 3, 4, "world", "Hello").into_c_stack_list();
         assert_eq!(
             list,
             CStackList(
@@ -306,12 +321,12 @@ mod tests {
                 1
             )
         );
-        assert_eq!(().into_cstack_list(), CNil(()));
+        assert_eq!(().into_c_stack_list(), CNil(()));
     }
 
     #[test]
     fn index() {
-        let list = (1, 2.5, "Hello").into_cstack_list();
+        let list = (1, 2.5, "Hello").into_c_stack_list();
         assert_eq!(list[U0::new()], 1);
         assert_eq!(list[U1::new()], 2.5);
         assert_eq!(list[U2::new()], "Hello");
@@ -319,19 +334,19 @@ mod tests {
 
     #[test]
     fn slice() {
-        let list = (1, 2.5, 3, 4, "world", "Hello").into_cstack_list();
+        let list = (1, 2.5, 3, 4, "world", "Hello").into_c_stack_list();
         println!("{:?}", list[..U5::new()][U2::new()..]);
     }
 
     #[test]
     fn index_range_from() {
-        let list = (1, 2.5, "Hello").into_cstack_list();
+        let list = (1, 2.5, "Hello").into_c_stack_list();
         assert_eq!(list[U1::new()..][U1::new()], "Hello");
     }
 
     #[test]
     fn index_range_to() {
-        let list = (1, 2.5, "Hello").into_cstack_list();
+        let list = (1, 2.5, "Hello").into_c_stack_list();
         assert_eq!(list[..U2::new()][U1::new()], 2.5);
     }
 

--- a/src/dyn_segment.rs
+++ b/src/dyn_segment.rs
@@ -3,7 +3,7 @@ use crate::list_traits::{List, ListTypeIteratorAdvance, TypeIdIterator};
 use crate::memory::align_index;
 use crate::raw_segment::RawSegment;
 use crate::raw_stack::RawStack;
-use crate::{CStackListMemoryLayout, ReverseList};
+use crate::{CStackListHeadLimit, CStackListHeadPadded, ReverseList};
 use anyhow::Result;
 use anyhow::ensure;
 use std::any::TypeId;
@@ -24,7 +24,7 @@ impl ToTypeIdList for CNil<()> {
     }
 }
 
-impl<H: 'static, T: ToTypeIdList + 'static + CStackListMemoryLayout> ToTypeIdList
+impl<H: 'static, T: ToTypeIdList + 'static + CStackListHeadLimit> ToTypeIdList
     for CStackList<H, T>
 {
     fn to_stack_info_list() -> Vec<StackInfo> {

--- a/src/dyn_segment.rs
+++ b/src/dyn_segment.rs
@@ -1,9 +1,9 @@
-use crate::ReverseList;
 use crate::c_stack_list::{CNil, CStackList, IntoCStackList};
 use crate::list_traits::{List, ListTypeIteratorAdvance, TypeIdIterator};
 use crate::memory::align_index;
 use crate::raw_segment::RawSegment;
 use crate::raw_stack::RawStack;
+use crate::{CStackListMemoryLayout, ReverseList};
 use anyhow::Result;
 use anyhow::ensure;
 use std::any::TypeId;
@@ -24,13 +24,15 @@ impl ToTypeIdList for CNil<()> {
     }
 }
 
-impl<H: 'static, T: ToTypeIdList + 'static> ToTypeIdList for CStackList<H, T> {
+impl<H: 'static, T: ToTypeIdList + 'static + CStackListMemoryLayout> ToTypeIdList
+    for CStackList<H, T>
+{
     fn to_stack_info_list() -> Vec<StackInfo> {
         let mut list = T::to_stack_info_list();
         list.push(StackInfo {
             stack_id: TypeId::of::<H>(),
-            stack_unwind: |stack| unsafe { stack.drop::<H>(Self::HEAD_PADDING != 0) },
-            padded: Self::HEAD_PADDING != 0,
+            stack_unwind: |stack| unsafe { stack.drop::<H>(Self::HEAD_PADDED) },
+            padded: Self::HEAD_PADDED,
         });
         list
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! cel-rs provides a stack-based runtime for developing domain specific languages, including
-//! concative languages to describe concurrent processes. A sequence is a list of operations (the
-//! machine instructions). Each operation is a closure that takes it's arguments from the stack and
-//! the result is pushed back onto the stack.
+//! concatenative languages to describe concurrent processes. A sequence is a list of operations
+//! (the machine instructions). Each operation is a closure that takes it's arguments from the stack
+//! and the result is pushed back onto the stack.
 //!
 //! Segments can be created in two ways.
 //!
@@ -34,7 +34,7 @@
 
 // #![warn(missing_docs)]
 pub mod c_stack_list;
-pub mod dyn_sement;
+pub mod dyn_segment;
 pub mod list_traits;
 pub mod memory;
 pub mod raw_segment;
@@ -45,7 +45,7 @@ pub mod segment;
 pub mod tuple_list;
 
 pub use c_stack_list::*;
-pub use dyn_sement::*;
+pub use dyn_segment::*;
 pub use list_traits::*;
 pub use memory::*;
 pub use raw_segment::*;

--- a/src/list_traits.rs
+++ b/src/list_traits.rs
@@ -42,10 +42,6 @@ pub trait List {
 
     // ---
 
-    /// For a `CStackList`, the number of padding bytes between Tail and Head.
-    /// This property will be moved to `CStackList` once I figure out a clean way to do it.
-    const HEAD_PADDING: usize;
-
     /// The style of `List` appended to `Self`
     type Append<U: List>: List;
 
@@ -157,7 +153,6 @@ impl<T: EmptyList> List for T {
     }
 
     const LENGTH: usize = 0;
-    const HEAD_PADDING: usize = 0;
 
     type Append<U: List> = U;
     fn append<U: List>(self, other: U) -> Self::Append<U> {

--- a/src/tuple_list.rs
+++ b/src/tuple_list.rs
@@ -69,8 +69,6 @@ impl<H: 'static, T: List> List for (H, T) {
         &self.1
     }
 
-    const HEAD_PADDING: usize = usize::MAX; // undefined
-
     type Push<U: 'static> = (U, Self);
     fn push<U: 'static>(self, item: U) -> Self::Push<U> {
         (item, self)


### PR DESCRIPTION
- Fixed an issue with stack padding being incorrect if the tail was padded for alignment.
- Improved the type correctness of HEAD_PADDING and limited the possible usage to only valid cases.
- Other minor changes for comments and parser error reporting.