### PR TITLE
Enhance documentation and update .gitignore for clarity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.tokensave

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,10 +78,9 @@ Every function must have a `///` doc comment written in **contract style**. The 
 **Required sections** (include only those that apply):
 
 1. **Summary** — A concise present-tense sentence fragment describing what the function does or returns, ending with a period.
-2. **Preconditions** — expressed as Rust standard sections:
-   - `# Panics` — conditions that cause a panic.
-   - `# Errors` — conditions that cause an `Err` return.
-   - `# Safety` — invariants the caller must uphold for `unsafe` functions.
+2. **Preconditions** — Non-obvious preconditions not implied by the summary, as `/// - Precondition: <condition>` bullets. Preconditions implied by the summary need not be restated. Violation has unspecified behavior (which may include a panic); do NOT document what happens on violation — instead use `debug_assert!()` to check preconditions in debug builds.
+   - `# Errors` — conditions that cause an `Err` return (runtime errors, not precondition violations).
+   - `# Safety` — invariants the caller must uphold for `unsafe` functions. This is the one place where the consequence of violation (undefined behavior) must be documented.
 3. **Postconditions** — `/// - Postcondition: <condition>` bullet in the body, only when not implicit in the summary.
 4. **Complexity** — `/// - Complexity: <description>` bullet, **required whenever the operation is not O(1)**. Default assumption is O(1) time and space.
 
@@ -94,11 +93,9 @@ Additional rules:
 
 **Example:**
 ```rust
-/// Removes and returns the top element of the stack.
+/// Removes and returns the top element.
 ///
-/// # Panics
-///
-/// Panics if the stack is empty.
+/// - Precondition: `padding` matches the value returned by the corresponding `push`.
 ///
 /// - Complexity: O(1).
 pub fn pop<T>(&mut self, padding: bool) -> T
@@ -108,12 +105,11 @@ pub fn pop<T>(&mut self, padding: bool) -> T
 
 Derive tests from the **contract and public interface only** — do not read or consider the implementation. The test suite verifies observable behavior as specified by the contract:
 
-- Each `# Panics` condition should have a `#[should_panic]` test (when safely testable).
 - Each `# Errors` condition should assert the `Err` variant is returned.
 - Each postcondition should be asserted.
 - Edge cases implied by the summary (empty input, single element, boundary values) should be covered.
 
-Tests written against the implementation risk encoding bugs rather than verifying intent.
+Precondition violations have unspecified behavior and should not be tested. Tests written against the implementation risk encoding bugs rather than verifying intent.
 
 ### Fallible ops
 Operations that can fail use `.op1r` / `.op2r` variants (returning `Result`) rather than `.op1` / `.op2`. Arithmetic on signed integers must use `checked_*` operations, not wrapping arithmetic.

--- a/cel-parser/src/op_table.rs
+++ b/cel-parser/src/op_table.rs
@@ -49,15 +49,14 @@ pub type ScopeFn = Box<dyn Fn(&str, &mut DynSegment, usize) -> Result<bool> + Se
 
 /// A signature for a built-in operation.
 ///
-/// Homogeneous ops (e.g. `u32 + u32`) leave `rhs_type_id_index` as `None`; all operands
-/// must match `type_id_index`. Heterogeneous binary ops (e.g. `u64 << u32`) set
-/// `rhs_type_id_index` to the RHS type, leaving `type_id_index` for the LHS.
+/// For homogeneous ops (e.g. `u32 + u32`) `rhs_type_id_index` equals `type_id_index`.
+/// For heterogeneous binary ops (e.g. `u64 << u32`) they differ.
 #[derive(Clone, Copy)]
 struct OpSignature {
     /// Index into TYPE_IDS for the LHS (or sole) operand type.
     type_id_index: usize,
-    /// Index into TYPE_IDS for the RHS operand type; `None` means same as LHS.
-    rhs_type_id_index: Option<usize>,
+    /// Index into TYPE_IDS for the RHS operand type; equals `type_id_index` for homogeneous ops.
+    rhs_type_id_index: usize,
     /// Number of operands this operation accepts.
     arity: u8,
     /// Function pointer to the operation implementation.
@@ -65,12 +64,14 @@ struct OpSignature {
 }
 
 impl OpSignature {
+    /// Returns the `TypeId` of the LHS (or sole) operand.
     fn lhs_type_id(&self) -> TypeId {
         TYPE_IDS[self.type_id_index]
     }
 
+    /// Returns the `TypeId` of the RHS operand.
     fn rhs_type_id(&self) -> TypeId {
-        TYPE_IDS[self.rhs_type_id_index.unwrap_or(self.type_id_index)]
+        TYPE_IDS[self.rhs_type_id_index]
     }
 }
 
@@ -122,7 +123,7 @@ macro_rules! sig {
     ($type_idx:expr, $arity:expr, $closure:expr) => {
         OpSignature {
             type_id_index: $type_idx,
-            rhs_type_id_index: None,
+            rhs_type_id_index: $type_idx,
             arity: $arity,
             op_fn: $closure,
         }
@@ -133,7 +134,7 @@ macro_rules! sig_het {
     ($lhs_idx:expr, $rhs_idx:expr, $closure:expr) => {
         OpSignature {
             type_id_index: $lhs_idx,
-            rhs_type_id_index: Some($rhs_idx),
+            rhs_type_id_index: $rhs_idx,
             arity: 2,
             op_fn: $closure,
         }
@@ -757,6 +758,8 @@ impl BuiltinScope {
     /// Attempts to find and apply a built-in operation.
     ///
     /// Returns `Ok(true)` if found and applied, `Ok(false)` if not found.
+    ///
+    /// - Complexity: O(s) where s is the number of signatures registered for `name`.
     fn lookup(&self, name: &str, segment: &mut DynSegment, num_operands: usize) -> Result<bool> {
         let stack_infos = segment.peek_stack_infos(num_operands);
         let signatures: &[OpSignature] = match name {

--- a/cel-runtime/src/dyn_segment.rs
+++ b/cel-runtime/src/dyn_segment.rs
@@ -192,6 +192,9 @@ impl DynSegment {
         self.stack_index = aligned_index + size_of::<T>();
     }
 
+    /// Returns the padding flags for the top N entries of the type stack.
+    ///
+    /// - Complexity: O(N).
     fn get_last_n_padded<const N: usize>(&self) -> [bool; N] {
         let mut result = [false; N];
         let start = self.stack_ids.len().saturating_sub(N);
@@ -202,6 +205,8 @@ impl DynSegment {
     }
 
     /// Captures the current stack droppers for use when unwinding on error.
+    ///
+    /// - Complexity: O(n) in the current stack depth.
     fn capture_unwind(&self) -> Vec<Dropper> {
         self.stack_ids.iter().map(|info| info.dropper).collect()
     }
@@ -248,15 +253,6 @@ impl DynSegment {
     ///
     /// If the operation succeeds, the result is pushed onto the stack. If it fails,
     /// the stack is unwound to its previous state and the error is propagated.
-    ///
-    /// # Arguments
-    ///
-    /// * `op` - A closure that returns a `Result<R>`
-    ///
-    /// # Type Parameters
-    ///
-    /// * `R` - The return type of the operation
-    /// * `F` - The closure type
     pub fn op0r<R, F>(&mut self, op: F)
     where
         F: Fn() -> anyhow::Result<R> + 'static,

--- a/cel-runtime/src/raw_segment.rs
+++ b/cel-runtime/src/raw_segment.rs
@@ -34,13 +34,14 @@ impl RawSegment {
         }
     }
 
-    /// Returns the maximum alignment required by any value stored in the segment.
+    /// Returns the maximum alignment required by any value pushed onto the stack while executing this segment.
     pub(crate) fn base_alignment(&self) -> usize {
         self.base_alignment
     }
 
-    /// Updates the base alignment to be at least `alignment`.
+    /// Updates the stack base alignment to be at least `alignment`.
     pub(crate) fn update_base_alignment(&mut self, alignment: usize) {
+        debug_assert!(alignment.is_power_of_two());
         self.base_alignment = max(self.base_alignment, alignment);
     }
 

--- a/cel-runtime/src/raw_segment.rs
+++ b/cel-runtime/src/raw_segment.rs
@@ -34,10 +34,12 @@ impl RawSegment {
         }
     }
 
+    /// Returns the maximum alignment required by any value stored in the segment.
     pub(crate) fn base_alignment(&self) -> usize {
         self.base_alignment
     }
 
+    /// Updates the base alignment to be at least `alignment`.
     pub(crate) fn update_base_alignment(&mut self, alignment: usize) {
         self.base_alignment = max(self.base_alignment, alignment);
     }
@@ -52,11 +54,7 @@ impl RawSegment {
             .push(|storage, p| unsafe { storage.drop_in_place::<T>(p) });
     }
 
-    /// [Need a better name for this] raw0_ pushes an operation that takes the stack as the only
-    /// argument and handles pushing its result to the stack directly. This can probably be merged
-    /// with raw0. It is used in join2 in dyn_segment.rs, and some of that implementation should be
-    /// lowered into this file.
-    /// Push a closure that manipulates the stack directly and returns `()`.
+    /// Pushes a closure that manipulates the stack directly and returns `()`.
     pub fn raw0_<F>(&mut self, op: F)
     where
         F: Fn(&mut RawStack) -> Result<()> + 'static,
@@ -100,6 +98,7 @@ impl RawSegment {
         self.base_alignment = max(self.base_alignment, align_of::<R>());
     }
 
+    /// Pushes the op-dispatch closure for a unary infallible operation with compile-time padding.
     fn push_op1_<const PADDING0: bool, T, R, F>(&mut self)
     where
         F: Fn(T) -> R + 'static,
@@ -114,6 +113,7 @@ impl RawSegment {
         });
     }
 
+    /// Pushes the op-dispatch closure for a unary fallible operation with compile-time padding.
     fn push_op1r_<const PADDING0: bool, T, R, F>(&mut self)
     where
         F: Fn(&mut RawStack, T) -> Result<R> + 'static,
@@ -161,6 +161,7 @@ impl RawSegment {
         self.base_alignment = max(self.base_alignment, align_of::<R>());
     }
 
+    /// Pushes the op-dispatch closure for a unary drop operation with compile-time padding.
     fn drop1_<const PADDING0: bool, T, F>(&mut self)
     where
         F: Fn(T) + 'static,
@@ -188,6 +189,7 @@ impl RawSegment {
         }
     }
 
+    /// Pushes the op-dispatch closure for a binary infallible operation with compile-time padding.
     fn push_op2_<const PADDING0: bool, const PADDING1: bool, T, U, R, F>(&mut self)
     where
         F: Fn(T, U) -> R + 'static,
@@ -223,6 +225,7 @@ impl RawSegment {
         self.base_alignment = max(self.base_alignment, align_of::<R>());
     }
 
+    /// Pushes the op-dispatch closure for a binary fallible operation with compile-time padding.
     fn push_op2r_<const PADDING0: bool, const PADDING1: bool, T, U, R, F>(&mut self)
     where
         F: Fn(&mut RawStack, T, U) -> Result<R> + 'static,


### PR DESCRIPTION
This pull request focuses on improving code documentation and clarifying contract requirements, as well as simplifying and clarifying the implementation of operation signatures and stack manipulation in the codebase. The most important changes are grouped below by theme.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation and a struct-field representation refactor with equivalent homogeneous-op semantics; no dispatch logic changes beyond the simplified RHS index access.
> 
> **Overview**
> Updates **CLAUDE.md** so function contracts use **precondition bullets** (with `debug_assert!` in debug) instead of documenting `# Panics` for contract violations, and tells tests not to assert on precondition violations.
> 
> Adds **`.tokensave`** to **`.gitignore`**.
> 
> In **`cel-parser` `op_table`**, **`OpSignature::rhs_type_id_index`** is always a **`usize`** (homogeneous ops duplicate the LHS index via **`sig!`**), replacing **`Option<usize>`** and the **`unwrap_or`** in **`rhs_type_id()`**. Builtin lookup documents **O(s)** complexity.
> 
> **`cel-runtime`** gets contract-style **`///`** on stack helpers (**`get_last_n_padded`**, **`capture_unwind`**), trims redundant **`op0r`** docs, clarifies **`RawSegment`** alignment helpers (including **`debug_assert!`** on power-of-two alignment), and replaces a placeholder comment on **`raw0_`** with a short summary plus doc on internal op-dispatch helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4e57145f1c2120d39a3d8f7b1b2fa39d503a859. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->