### PR TITLE
Add if/else/else-if expressions and short-circuit &&/|| operators

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+if ! cargo fmt --all --check; then
+    echo "Formatting check failed. Run 'cargo fmt --all' and re-stage the changes."
+    exit 1
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,20 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Setup
+
+After cloning, activate the shared git hooks (one-time):
+
+```bash
+git config core.hooksPath .githooks
+```
+
 ## Commands
 
 ```bash
+# Format (required before every commit; enforced by pre-commit hook)
+cargo fmt --all
+
 # Build
 cargo build --workspace
 

--- a/cel-parser/src/lib.rs
+++ b/cel-parser/src/lib.rs
@@ -467,19 +467,18 @@ impl CELParser {
 
     /// `and_expression = comparison_expression { "&&" comparison_expression }.`
     fn is_and_expression(&mut self) -> Result<bool> {
-        let start_span = self.peek_span();
         if self.is_comparison_expression()? {
             while self.is_punctuation("&&") {
+                let mut rhs_fragment = self.context.new_fragment();
+                std::mem::swap(&mut self.context, &mut rhs_fragment);
                 if !self.is_comparison_expression()? {
                     return Err(self.error_at("expected comparison_expression"));
                 }
-                self.op_lookup.lookup(
-                    "&&",
-                    &mut self.context,
-                    2,
-                    start_span.expect("production has token at start"),
-                    self.last_span,
-                )?;
+                std::mem::swap(&mut self.context, &mut rhs_fragment);
+                let mut bypass_fragment = self.context.new_fragment();
+                bypass_fragment.just(false);
+                self.context.join2(rhs_fragment, bypass_fragment)
+                    .map_err(|e| ParseError::new(e.to_string(), self.last_span))?;
             }
             Ok(true)
         } else {
@@ -1528,5 +1527,41 @@ mod playground {
                 e.format_rustc_style(source, file!(), line, &Renderer::styled())
             ),
         }
+    }
+
+    #[test]
+    fn and_short_circuits_on_false() {
+        // Without short-circuit the RHS executes and division-by-zero errors.
+        // With short-circuit the RHS fragment is skipped, returning false directly.
+        let mut parser = CELParser::new(OpLookup::new());
+        let mut segment = parser
+            .parse_str("false && (1i32 / 0i32 == 0i32)")
+            .expect("should parse");
+        assert_eq!(segment.call0::<bool>().unwrap(), false);
+    }
+
+    #[test]
+    fn and_evaluates_rhs_when_lhs_true() {
+        let mut parser = CELParser::new(OpLookup::new());
+        let mut segment = parser
+            .parse_str("true && false")
+            .expect("should parse");
+        assert_eq!(segment.call0::<bool>().unwrap(), false);
+    }
+
+    #[test]
+    fn and_chained_short_circuits() {
+        let mut parser = CELParser::new(OpLookup::new());
+        let mut segment = parser
+            .parse_str("false && false && false")
+            .expect("should parse");
+        assert_eq!(segment.call0::<bool>().unwrap(), false);
+    }
+
+    #[test]
+    fn and_lhs_type_error() {
+        // LHS is i32, not bool — join2 must reject it at parse time.
+        let mut parser = CELParser::new(OpLookup::new());
+        assert!(parser.parse_str("1i32 && true").is_err());
     }
 }

--- a/cel-parser/src/lib.rs
+++ b/cel-parser/src/lib.rs
@@ -874,6 +874,8 @@ impl CELParser {
     /// Returns an error if the condition is missing, if a `{` or `}` delimiter is missing,
     /// if the then-branch or else-branch expression is missing, or if the then and else
     /// branch types do not match (as detected by `join2`).
+    ///
+    /// - Postcondition: Returns `Ok(true)` on success; `Ok(false)` is never returned.
     fn is_if_expression(&mut self) -> Result<bool> {
         if !self.is_or_expression()? {
             return Err(self.error_at("expected condition after `if`"));
@@ -1649,6 +1651,13 @@ mod tests {
     }
 
     #[test]
+    fn or_lhs_type_error() {
+        // LHS is i32, not bool — join2 must reject it at parse time.
+        let mut parser = CELParser::new(OpLookup::new());
+        assert!(parser.parse_str("1i32 || true").is_err());
+    }
+
+    #[test]
     fn or_short_circuits_on_true() {
         // Without short-circuit the RHS executes and division-by-zero errors.
         // With short-circuit the RHS fragment is skipped, returning true directly.
@@ -1758,6 +1767,13 @@ mod tests {
             .parse_str("if false { () }")
             .expect("should parse");
         segment.call0::<()>().expect("should execute");
+    }
+
+    #[test]
+    fn if_trailing_else_is_error() {
+        // `else` with no body is a parse error.
+        let mut parser = CELParser::new(OpLookup::new());
+        assert!(parser.parse_str("if true { () } else").is_err());
     }
 }
 

--- a/cel-parser/src/lib.rs
+++ b/cel-parser/src/lib.rs
@@ -26,7 +26,8 @@
 //! multiplicative_expression = unary_expression { ("*" | "/" | "%") unary_expression }.
 //! unary_expression = (("-" | "!") unary_expression) | postfix_expression.
 //! postfix_expression = primary_expression { "(" parameter_list ")" }.
-//! primary_expression = literal | identifier | "(" or_expression ")".
+//! primary_expression = literal | identifier | "(" or_expression ")" | if_expression.
+//! if_expression = "if" or_expression "{" or_expression "}" [ "else" ( "{" or_expression "}" | if_expression ) ].
 //! parameter_list = [ or_expression { "," or_expression } ].
 //! ```
 //!
@@ -432,6 +433,17 @@ impl CELParser {
         }
     }
 
+    /// Consumes and returns `true` if the next token is an identifier matching `keyword`.
+    fn is_keyword(&mut self, keyword: &str) -> bool {
+        match self.peek_token() {
+            Some(Token::Identifier(ident)) if ident == keyword => {
+                self.advance();
+                true
+            }
+            _ => false,
+        }
+    }
+
     /// `expression = or_expression <EOF>.`
     pub fn is_expression(&mut self) -> Result<bool> {
         if !self.is_or_expression()? {
@@ -785,7 +797,14 @@ impl CELParser {
         Ok(count)
     }
 
-    /// `primary_expression = literal | identifier | "(" or_expression ")".`
+    /// `primary_expression = literal | identifier | "(" or_expression ")" | if_expression.`
+    ///
+    /// Dispatches to [`is_if_expression`](Self::is_if_expression) when the `if` keyword is seen.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a parenthesized expression is malformed, or if an `if` expression
+    /// fails to parse.
     fn is_primary_expression(&mut self) -> Result<bool> {
         match self.peek_token() {
             Some(Token::Literal(lit)) => {
@@ -799,6 +818,10 @@ impl CELParser {
                 let ident_span = ident.span();
                 self.advance();
 
+                if ident_name == "if" {
+                    return self.is_if_expression();
+                }
+
                 self.op_lookup
                     .lookup(&ident_name, &mut self.context, 0, ident_span, ident_span)?;
 
@@ -809,6 +832,18 @@ impl CELParser {
                 ..
             }) => {
                 self.advance();
+                // Unit expression: ()
+                if matches!(
+                    self.peek_token(),
+                    Some(Token::CloseDelim {
+                        delimiter: Delimiter::Parenthesis,
+                        ..
+                    })
+                ) {
+                    self.advance();
+                    self.context.just(());
+                    return Ok(true);
+                }
                 if !self.is_or_expression()? {
                     return Err(self.error_at("expected expression"));
                 }
@@ -817,7 +852,7 @@ impl CELParser {
                         delimiter: Delimiter::Parenthesis,
                         ..
                     }) => {
-                        self.advance(); // consume CloseDelim
+                        self.advance();
                         Ok(true)
                     }
                     _ => Err(self.error_at("expected closing parenthesis")),
@@ -825,6 +860,91 @@ impl CELParser {
             }
             _ => Ok(false),
         }
+    }
+
+    /// `if_expression = "if" or_expression "{" or_expression "}" [ "else" ( "{" or_expression "}" | if_expression ) ].`
+    ///
+    /// - Precondition: The `if` keyword has already been consumed by the caller.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the condition is missing, if a `{` or `}` delimiter is missing,
+    /// if the then-branch or else-branch expression is missing, or if the then and else
+    /// branch types do not match (as detected by `join2`).
+    fn is_if_expression(&mut self) -> Result<bool> {
+        if !self.is_or_expression()? {
+            return Err(self.error_at("expected condition after `if`"));
+        }
+        match self.peek_token() {
+            Some(Token::OpenDelim {
+                delimiter: Delimiter::Brace,
+                ..
+            }) => {
+                self.advance();
+            }
+            _ => return Err(self.error_at("expected `{` after if condition")),
+        }
+        let mut then_fragment = self.context.new_fragment();
+        std::mem::swap(&mut self.context, &mut then_fragment);
+        if !self.is_or_expression()? {
+            return Err(self.error_at("expected expression in then-branch"));
+        }
+        std::mem::swap(&mut self.context, &mut then_fragment);
+        match self.peek_token() {
+            Some(Token::CloseDelim {
+                delimiter: Delimiter::Brace,
+                ..
+            }) => {
+                self.advance();
+            }
+            _ => return Err(self.error_at("expected `}` after then-branch")),
+        }
+        let else_fragment = if self.is_keyword("else") {
+            if self.is_keyword("if") {
+                // else if: recursively parse another if_expression
+                let mut fragment = self.context.new_fragment();
+                std::mem::swap(&mut self.context, &mut fragment);
+                self.is_if_expression()?;
+                std::mem::swap(&mut self.context, &mut fragment);
+                fragment
+            } else {
+                // else { expr }
+                match self.peek_token() {
+                    Some(Token::OpenDelim {
+                        delimiter: Delimiter::Brace,
+                        ..
+                    }) => {
+                        self.advance();
+                    }
+                    _ => return Err(self.error_at("expected `{` or `if` after `else`")),
+                }
+                let mut fragment = self.context.new_fragment();
+                std::mem::swap(&mut self.context, &mut fragment);
+                if !self.is_or_expression()? {
+                    return Err(self.error_at("expected expression in else-branch"));
+                }
+                std::mem::swap(&mut self.context, &mut fragment);
+                match self.peek_token() {
+                    Some(Token::CloseDelim {
+                        delimiter: Delimiter::Brace,
+                        ..
+                    }) => {
+                        self.advance();
+                    }
+                    _ => return Err(self.error_at("expected `}` after else-branch")),
+                }
+                fragment
+            }
+        } else {
+            // Implicit else: () — then-branch must also return ()
+            let mut fragment = self.context.new_fragment();
+            fragment.just(());
+            fragment
+        };
+        self.context
+            .join2(then_fragment, else_fragment)
+            .map_err(|e| ParseError::new(e.to_string(), self.last_span))?;
+        Ok(true)
     }
 }
 
@@ -1552,6 +1672,89 @@ mod tests {
             .parse_str("true || false || false")
             .expect("should parse");
         assert_eq!(segment.call0::<bool>().unwrap(), true);
+    }
+
+    #[test]
+    fn if_true_branch_selected() {
+        let mut parser = CELParser::new(OpLookup::new());
+        let mut segment = parser
+            .parse_str("if true { 1i32 } else { 2i32 }")
+            .expect("should parse");
+        assert_eq!(segment.call0::<i32>().unwrap(), 1);
+    }
+
+    #[test]
+    fn if_false_branch_selected() {
+        let mut parser = CELParser::new(OpLookup::new());
+        let mut segment = parser
+            .parse_str("if false { 1i32 } else { 2i32 }")
+            .expect("should parse");
+        assert_eq!(segment.call0::<i32>().unwrap(), 2);
+    }
+
+    #[test]
+    fn if_else_if_first_branch() {
+        let mut parser = CELParser::new(OpLookup::new());
+        let mut segment = parser
+            .parse_str("if true { 1i32 } else if false { 2i32 } else { 3i32 }")
+            .expect("should parse");
+        assert_eq!(segment.call0::<i32>().unwrap(), 1);
+    }
+
+    #[test]
+    fn if_else_if_middle_branch() {
+        let mut parser = CELParser::new(OpLookup::new());
+        let mut segment = parser
+            .parse_str("if false { 1i32 } else if true { 2i32 } else { 3i32 }")
+            .expect("should parse");
+        assert_eq!(segment.call0::<i32>().unwrap(), 2);
+    }
+
+    #[test]
+    fn if_else_if_last_branch() {
+        let mut parser = CELParser::new(OpLookup::new());
+        let mut segment = parser
+            .parse_str("if false { 1i32 } else if false { 2i32 } else { 3i32 }")
+            .expect("should parse");
+        assert_eq!(segment.call0::<i32>().unwrap(), 3);
+    }
+
+    #[test]
+    fn if_omitted_else_unit_branch() {
+        let mut parser = CELParser::new(OpLookup::new());
+        let mut segment = parser
+            .parse_str("if true { () }")
+            .expect("should parse");
+        segment.call0::<()>().expect("should execute");
+    }
+
+    #[test]
+    fn if_omitted_else_rejects_non_unit_then() {
+        // then-branch returns i32, implicit else returns () — types must match.
+        let mut parser = CELParser::new(OpLookup::new());
+        assert!(parser.parse_str("if false { 1i32 }").is_err());
+    }
+
+    #[test]
+    fn if_branch_type_mismatch_is_error() {
+        let mut parser = CELParser::new(OpLookup::new());
+        assert!(parser.parse_str("if true { 1i32 } else { true }").is_err());
+    }
+
+    #[test]
+    fn if_missing_open_brace_is_error() {
+        let mut parser = CELParser::new(OpLookup::new());
+        assert!(parser.parse_str("if true 1i32 } else { 2i32 }").is_err());
+    }
+
+    #[test]
+    fn if_missing_else_after_brace_is_fine() {
+        // Omitting else is allowed; result type must be ().
+        let mut parser = CELParser::new(OpLookup::new());
+        let mut segment = parser
+            .parse_str("if false { () }")
+            .expect("should parse");
+        segment.call0::<()>().expect("should execute");
     }
 }
 

--- a/cel-parser/src/lib.rs
+++ b/cel-parser/src/lib.rs
@@ -462,6 +462,7 @@ impl CELParser {
     /// Returns an error if the RHS is missing after `||`, if the RHS does not
     /// produce a `bool`, or if any sub-expression returns an error.
     fn is_or_expression(&mut self) -> Result<bool> {
+        let start_span = self.peek_span();
         if self.is_and_expression()? {
             while self.is_punctuation("||") {
                 let mut rhs_fragment = self.context.new_fragment();
@@ -474,7 +475,13 @@ impl CELParser {
                 bypass_fragment.just(true);
                 self.context
                     .join2(bypass_fragment, rhs_fragment)
-                    .map_err(|e| ParseError::new(e.to_string(), self.last_span))?;
+                    .map_err(|e| {
+                        ParseError::new_range(
+                            e.to_string(),
+                            start_span.expect("production has token at start"),
+                            self.last_span,
+                        )
+                    })?;
             }
             Ok(true)
         } else {
@@ -489,6 +496,7 @@ impl CELParser {
     /// Returns an error if the RHS is missing after `&&`, if the RHS does not
     /// produce a `bool`, or if any sub-expression returns an error.
     fn is_and_expression(&mut self) -> Result<bool> {
+        let start_span = self.peek_span();
         if self.is_comparison_expression()? {
             while self.is_punctuation("&&") {
                 let mut rhs_fragment = self.context.new_fragment();
@@ -501,7 +509,13 @@ impl CELParser {
                 bypass_fragment.just(false);
                 self.context
                     .join2(rhs_fragment, bypass_fragment)
-                    .map_err(|e| ParseError::new(e.to_string(), self.last_span))?;
+                    .map_err(|e| {
+                        ParseError::new_range(
+                            e.to_string(),
+                            start_span.expect("production has token at start"),
+                            self.last_span,
+                        )
+                    })?;
             }
             Ok(true)
         } else {
@@ -1647,14 +1661,22 @@ mod tests {
     fn and_lhs_type_error() {
         // LHS is i32, not bool — join2 must reject it at parse time.
         let mut parser = CELParser::new(OpLookup::new());
-        assert!(parser.parse_str("1i32 && true").is_err());
+        let err = match parser.parse_str("1i32 && true") {
+            Err(e) => e,
+            Ok(_) => panic!("lhs i32 should fail for &&"),
+        };
+        assert!(err.end_span().is_some());
     }
 
     #[test]
     fn or_lhs_type_error() {
         // LHS is i32, not bool — join2 must reject it at parse time.
         let mut parser = CELParser::new(OpLookup::new());
-        assert!(parser.parse_str("1i32 || true").is_err());
+        let err = match parser.parse_str("1i32 || true") {
+            Err(e) => e,
+            Ok(_) => panic!("lhs i32 should fail for ||"),
+        };
+        assert!(err.end_span().is_some());
     }
 
     #[test]

--- a/cel-parser/src/lib.rs
+++ b/cel-parser/src/lib.rs
@@ -444,6 +444,11 @@ impl CELParser {
     }
 
     /// `or_expression = and_expression { "||" and_expression }.`
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the RHS is missing after `||`, if the RHS does not
+    /// produce a `bool`, or if any sub-expression returns an error.
     fn is_or_expression(&mut self) -> Result<bool> {
         if self.is_and_expression()? {
             while self.is_punctuation("||") {

--- a/cel-parser/src/lib.rs
+++ b/cel-parser/src/lib.rs
@@ -803,8 +803,11 @@ impl CELParser {
     ///
     /// # Errors
     ///
-    /// Returns an error if a parenthesized expression is malformed, or if an `if` expression
-    /// fails to parse.
+    /// Returns an error if:
+    /// - A literal value cannot be parsed (e.g., integer out of range).
+    /// - An identifier is not found in the op lookup table.
+    /// - A parenthesized expression is malformed or missing its closing `)`.
+    /// - An `if` expression fails to parse.
     fn is_primary_expression(&mut self) -> Result<bool> {
         match self.peek_token() {
             Some(Token::Literal(lit)) => {

--- a/cel-parser/src/lib.rs
+++ b/cel-parser/src/lib.rs
@@ -472,7 +472,8 @@ impl CELParser {
                 std::mem::swap(&mut self.context, &mut rhs_fragment);
                 let mut bypass_fragment = self.context.new_fragment();
                 bypass_fragment.just(true);
-                self.context.join2(bypass_fragment, rhs_fragment)
+                self.context
+                    .join2(bypass_fragment, rhs_fragment)
                     .map_err(|e| ParseError::new(e.to_string(), self.last_span))?;
             }
             Ok(true)
@@ -498,7 +499,8 @@ impl CELParser {
                 std::mem::swap(&mut self.context, &mut rhs_fragment);
                 let mut bypass_fragment = self.context.new_fragment();
                 bypass_fragment.just(false);
-                self.context.join2(rhs_fragment, bypass_fragment)
+                self.context
+                    .join2(rhs_fragment, bypass_fragment)
                     .map_err(|e| ParseError::new(e.to_string(), self.last_span))?;
             }
             Ok(true)
@@ -1628,9 +1630,7 @@ mod tests {
     #[test]
     fn and_evaluates_rhs_when_lhs_true() {
         let mut parser = CELParser::new(OpLookup::new());
-        let mut segment = parser
-            .parse_str("true && false")
-            .expect("should parse");
+        let mut segment = parser.parse_str("true && false").expect("should parse");
         assert_eq!(segment.call0::<bool>().unwrap(), false);
     }
 
@@ -1671,9 +1671,7 @@ mod tests {
     #[test]
     fn or_evaluates_rhs_when_lhs_false() {
         let mut parser = CELParser::new(OpLookup::new());
-        let mut segment = parser
-            .parse_str("false || true")
-            .expect("should parse");
+        let mut segment = parser.parse_str("false || true").expect("should parse");
         assert_eq!(segment.call0::<bool>().unwrap(), true);
     }
 
@@ -1734,9 +1732,7 @@ mod tests {
     #[test]
     fn if_omitted_else_unit_branch() {
         let mut parser = CELParser::new(OpLookup::new());
-        let mut segment = parser
-            .parse_str("if true { () }")
-            .expect("should parse");
+        let mut segment = parser.parse_str("if true { () }").expect("should parse");
         segment.call0::<()>().expect("should execute");
     }
 
@@ -1763,9 +1759,7 @@ mod tests {
     fn if_missing_else_after_brace_is_fine() {
         // Omitting else is allowed; result type must be ().
         let mut parser = CELParser::new(OpLookup::new());
-        let mut segment = parser
-            .parse_str("if false { () }")
-            .expect("should parse");
+        let mut segment = parser.parse_str("if false { () }").expect("should parse");
         segment.call0::<()>().expect("should execute");
     }
 

--- a/cel-parser/src/lib.rs
+++ b/cel-parser/src/lib.rs
@@ -445,19 +445,18 @@ impl CELParser {
 
     /// `or_expression = and_expression { "||" and_expression }.`
     fn is_or_expression(&mut self) -> Result<bool> {
-        let start_span = self.peek_span();
         if self.is_and_expression()? {
             while self.is_punctuation("||") {
+                let mut rhs_fragment = self.context.new_fragment();
+                std::mem::swap(&mut self.context, &mut rhs_fragment);
                 if !self.is_and_expression()? {
                     return Err(self.error_at("expected and_expression"));
                 }
-                self.op_lookup.lookup(
-                    "||",
-                    &mut self.context,
-                    2,
-                    start_span.expect("production has token at start"),
-                    self.last_span,
-                )?;
+                std::mem::swap(&mut self.context, &mut rhs_fragment);
+                let mut bypass_fragment = self.context.new_fragment();
+                bypass_fragment.just(true);
+                self.context.join2(bypass_fragment, rhs_fragment)
+                    .map_err(|e| ParseError::new(e.to_string(), self.last_span))?;
             }
             Ok(true)
         } else {
@@ -1519,6 +1518,35 @@ mod tests {
         // LHS is i32, not bool — join2 must reject it at parse time.
         let mut parser = CELParser::new(OpLookup::new());
         assert!(parser.parse_str("1i32 && true").is_err());
+    }
+
+    #[test]
+    fn or_short_circuits_on_true() {
+        // Without short-circuit the RHS executes and division-by-zero errors.
+        // With short-circuit the RHS fragment is skipped, returning true directly.
+        let mut parser = CELParser::new(OpLookup::new());
+        let mut segment = parser
+            .parse_str("true || (1i32 / 0i32 == 0i32)")
+            .expect("should parse");
+        assert_eq!(segment.call0::<bool>().unwrap(), true);
+    }
+
+    #[test]
+    fn or_evaluates_rhs_when_lhs_false() {
+        let mut parser = CELParser::new(OpLookup::new());
+        let mut segment = parser
+            .parse_str("false || true")
+            .expect("should parse");
+        assert_eq!(segment.call0::<bool>().unwrap(), true);
+    }
+
+    #[test]
+    fn or_chained() {
+        let mut parser = CELParser::new(OpLookup::new());
+        let mut segment = parser
+            .parse_str("true || false || false")
+            .expect("should parse");
+        assert_eq!(segment.call0::<bool>().unwrap(), true);
     }
 }
 

--- a/cel-parser/src/lib.rs
+++ b/cel-parser/src/lib.rs
@@ -466,6 +466,11 @@ impl CELParser {
     }
 
     /// `and_expression = comparison_expression { "&&" comparison_expression }.`
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the RHS is missing after `&&`, if the RHS does not
+    /// produce a `bool`, or if any sub-expression returns an error.
     fn is_and_expression(&mut self) -> Result<bool> {
         if self.is_comparison_expression()? {
             while self.is_punctuation("&&") {
@@ -1479,6 +1484,42 @@ mod tests {
             end_span.end().column
         );
     }
+
+    #[test]
+    fn and_short_circuits_on_false() {
+        // Without short-circuit the RHS executes and division-by-zero errors.
+        // With short-circuit the RHS fragment is skipped, returning false directly.
+        let mut parser = CELParser::new(OpLookup::new());
+        let mut segment = parser
+            .parse_str("false && (1i32 / 0i32 == 0i32)")
+            .expect("should parse");
+        assert_eq!(segment.call0::<bool>().unwrap(), false);
+    }
+
+    #[test]
+    fn and_evaluates_rhs_when_lhs_true() {
+        let mut parser = CELParser::new(OpLookup::new());
+        let mut segment = parser
+            .parse_str("true && false")
+            .expect("should parse");
+        assert_eq!(segment.call0::<bool>().unwrap(), false);
+    }
+
+    #[test]
+    fn and_chained_short_circuits() {
+        let mut parser = CELParser::new(OpLookup::new());
+        let mut segment = parser
+            .parse_str("false && false && false")
+            .expect("should parse");
+        assert_eq!(segment.call0::<bool>().unwrap(), false);
+    }
+
+    #[test]
+    fn and_lhs_type_error() {
+        // LHS is i32, not bool — join2 must reject it at parse time.
+        let mut parser = CELParser::new(OpLookup::new());
+        assert!(parser.parse_str("1i32 && true").is_err());
+    }
 }
 
 #[cfg(test)]
@@ -1527,41 +1568,5 @@ mod playground {
                 e.format_rustc_style(source, file!(), line, &Renderer::styled())
             ),
         }
-    }
-
-    #[test]
-    fn and_short_circuits_on_false() {
-        // Without short-circuit the RHS executes and division-by-zero errors.
-        // With short-circuit the RHS fragment is skipped, returning false directly.
-        let mut parser = CELParser::new(OpLookup::new());
-        let mut segment = parser
-            .parse_str("false && (1i32 / 0i32 == 0i32)")
-            .expect("should parse");
-        assert_eq!(segment.call0::<bool>().unwrap(), false);
-    }
-
-    #[test]
-    fn and_evaluates_rhs_when_lhs_true() {
-        let mut parser = CELParser::new(OpLookup::new());
-        let mut segment = parser
-            .parse_str("true && false")
-            .expect("should parse");
-        assert_eq!(segment.call0::<bool>().unwrap(), false);
-    }
-
-    #[test]
-    fn and_chained_short_circuits() {
-        let mut parser = CELParser::new(OpLookup::new());
-        let mut segment = parser
-            .parse_str("false && false && false")
-            .expect("should parse");
-        assert_eq!(segment.call0::<bool>().unwrap(), false);
-    }
-
-    #[test]
-    fn and_lhs_type_error() {
-        // LHS is i32, not bool — join2 must reject it at parse time.
-        let mut parser = CELParser::new(OpLookup::new());
-        assert!(parser.parse_str("1i32 && true").is_err());
     }
 }

--- a/cel-parser/src/op_table.rs
+++ b/cel-parser/src/op_table.rs
@@ -599,10 +599,6 @@ static RIGHT_SHIFT_SIGNATURES: Lazy<Vec<OpSignature>> = Lazy::new(|| {
     v
 });
 
-// Logical AND signatures
-static LOGICAL_AND_SIGNATURES: &[OpSignature] =
-    &[sig!(TYPE_BOOL, 2, |seg| seg.op2(|a: bool, b: bool| a && b))];
-
 // Logical OR signatures
 static LOGICAL_OR_SIGNATURES: &[OpSignature] =
     &[sig!(TYPE_BOOL, 2, |seg| seg.op2(|a: bool, b: bool| a || b))];
@@ -738,7 +734,6 @@ static BUILTINS: phf::Map<&'static str, &'static [OpSignature]> = phf_map! {
     "&" => BITWISE_AND_SIGNATURES,
     "|" => BITWISE_OR_SIGNATURES,
     "^" => BITWISE_XOR_SIGNATURES,
-    "&&" => LOGICAL_AND_SIGNATURES,
     "||" => LOGICAL_OR_SIGNATURES,
     "!" => LOGICAL_NOT_SIGNATURES,
     "==" => EQUAL_SIGNATURES,
@@ -1031,17 +1026,6 @@ mod tests {
         segment.just(20u32);
         lookup.lookup("<", &mut segment, 2, Span::call_site(), Span::call_site())?;
         assert_eq!(segment.call0::<bool>()?, true);
-        Ok(())
-    }
-
-    #[test]
-    fn test_logical_and() -> Result<()> {
-        let lookup = OpLookup::new();
-        let mut segment = DynSegment::new::<()>();
-        segment.just(true);
-        segment.just(false);
-        lookup.lookup("&&", &mut segment, 2, Span::call_site(), Span::call_site())?;
-        assert_eq!(segment.call0::<bool>()?, false);
         Ok(())
     }
 

--- a/cel-parser/src/op_table.rs
+++ b/cel-parser/src/op_table.rs
@@ -599,10 +599,6 @@ static RIGHT_SHIFT_SIGNATURES: Lazy<Vec<OpSignature>> = Lazy::new(|| {
     v
 });
 
-// Logical OR signatures
-static LOGICAL_OR_SIGNATURES: &[OpSignature] =
-    &[sig!(TYPE_BOOL, 2, |seg| seg.op2(|a: bool, b: bool| a || b))];
-
 // Logical NOT signatures
 static LOGICAL_NOT_SIGNATURES: &[OpSignature] = &[sig!(TYPE_BOOL, 1, |seg| seg.op1(|a: bool| !a))];
 
@@ -734,7 +730,6 @@ static BUILTINS: phf::Map<&'static str, &'static [OpSignature]> = phf_map! {
     "&" => BITWISE_AND_SIGNATURES,
     "|" => BITWISE_OR_SIGNATURES,
     "^" => BITWISE_XOR_SIGNATURES,
-    "||" => LOGICAL_OR_SIGNATURES,
     "!" => LOGICAL_NOT_SIGNATURES,
     "==" => EQUAL_SIGNATURES,
     "!=" => NOT_EQUAL_SIGNATURES,

--- a/docs/superpowers/plans/2026-06-19-if-and-short-circuit.md
+++ b/docs/superpowers/plans/2026-06-19-if-and-short-circuit.md
@@ -1,0 +1,598 @@
+# if Expression and Short-Circuit &&/|| Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Rust-style `if`/`else`/`else if` expressions and true short-circuit `&&`/`||` to the CEL parser using `DynSegment::new_fragment()` and `join2()`.
+
+**Architecture:** The parser builds lazy sub-segments (fragments) via `context.new_fragment()`, uses a context-swap to redirect parsing into the fragment, then calls `context.join2(true_branch, false_branch)`. At runtime `join2` pops a `bool` from the stack and executes exactly one fragment. `&&`/`||` no longer go through the op-table; they are pure parse-time constructs. `if` is handled as a keyword inside the `Identifier` arm of `is_primary_expression`.
+
+**Tech Stack:** Rust, proc_macro2/syn (tokenisation), cel-runtime `DynSegment`/`RawSegment`.
+
+## Global Constraints
+
+- Every new/modified function must have a `///` doc comment in contract style (see CLAUDE.md).
+- Tests derive from the contract and public interface only — not from implementation.
+- `cargo clippy --workspace -- -D warnings` must produce zero warnings after every task.
+- No new `wrapping_*` arithmetic; signed integer ops use `checked_*`.
+
+---
+
+### Task 1: Short-circuit `&&`
+
+**Files:**
+- Modify: `cel-parser/src/lib.rs` — rewrite `is_and_expression`
+- Modify: `cel-parser/src/op_table.rs` — remove `LOGICAL_AND_SIGNATURES`, its `BUILTINS` entry, and `test_logical_and`
+
+**Interfaces:**
+- Produces: `is_and_expression(&mut self) -> Result<bool>` — same signature, new semantics (short-circuits when LHS is `false`)
+
+- [ ] **Step 1: Write failing tests**
+
+Add inside `mod tests` at the bottom of `cel-parser/src/lib.rs`:
+
+```rust
+#[test]
+fn and_short_circuits_on_false() {
+    // Without short-circuit the RHS executes and division-by-zero errors.
+    // With short-circuit the RHS fragment is skipped, returning false directly.
+    let mut parser = CELParser::new(OpLookup::new());
+    let mut segment = parser
+        .parse_str("false && (1i32 / 0i32 == 0i32)")
+        .expect("should parse");
+    assert_eq!(segment.call0::<bool>().unwrap(), false);
+}
+
+#[test]
+fn and_evaluates_rhs_when_lhs_true() {
+    let mut parser = CELParser::new(OpLookup::new());
+    let mut segment = parser
+        .parse_str("true && false")
+        .expect("should parse");
+    assert_eq!(segment.call0::<bool>().unwrap(), false);
+}
+
+#[test]
+fn and_chained_short_circuits() {
+    let mut parser = CELParser::new(OpLookup::new());
+    let mut segment = parser
+        .parse_str("false && false && false")
+        .expect("should parse");
+    assert_eq!(segment.call0::<bool>().unwrap(), false);
+}
+```
+
+```rust
+#[test]
+fn and_lhs_type_error() {
+    // LHS is i32, not bool — join2 must reject it at parse time.
+    let mut parser = CELParser::new(OpLookup::new());
+    assert!(parser.parse_str("1i32 && true").is_err());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cargo test --workspace and_short_circuits_on_false
+```
+
+Expected: FAIL — `and_short_circuits_on_false` errors with division-by-zero instead of returning `Ok(false)`. The other two correctness tests and the type-error test may already pass or already fail for the right reasons; the important one is `and_short_circuits_on_false`.
+
+- [ ] **Step 3: Rewrite `is_and_expression` in `cel-parser/src/lib.rs`**
+
+Find and replace the entire `is_and_expression` function (currently begins with `/// \`and_expression = ...`). The new version removes `start_span` and replaces the `op_lookup.lookup` call with a context-swap + `join2`:
+
+```rust
+/// `and_expression = comparison_expression { "&&" comparison_expression }.`
+fn is_and_expression(&mut self) -> Result<bool> {
+    if self.is_comparison_expression()? {
+        while self.is_punctuation("&&") {
+            let mut rhs_fragment = self.context.new_fragment();
+            std::mem::swap(&mut self.context, &mut rhs_fragment);
+            if !self.is_comparison_expression()? {
+                return Err(self.error_at("expected comparison_expression"));
+            }
+            std::mem::swap(&mut self.context, &mut rhs_fragment);
+            let mut bypass_fragment = self.context.new_fragment();
+            bypass_fragment.just(false);
+            self.context.join2(rhs_fragment, bypass_fragment)?;
+        }
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+```
+
+- [ ] **Step 4: Remove `&&` from `cel-parser/src/op_table.rs`**
+
+Remove the static array (including its comment):
+
+```rust
+// Logical AND signatures
+static LOGICAL_AND_SIGNATURES: &[OpSignature] =
+    &[sig!(TYPE_BOOL, 2, |seg| seg.op2(|a: bool, b: bool| a && b))];
+```
+
+Remove its entry from the `BUILTINS` phf map:
+
+```rust
+    "&&" => LOGICAL_AND_SIGNATURES,
+```
+
+Remove the entire `test_logical_and` test function:
+
+```rust
+#[test]
+fn test_logical_and() -> Result<()> {
+    let lookup = OpLookup::new();
+    let mut segment = DynSegment::new::<()>();
+    segment.just(true);
+    segment.just(false);
+    lookup.lookup("&&", &mut segment, 2, Span::call_site(), Span::call_site())?;
+    assert_eq!(segment.call0::<bool>()?, false);
+    Ok(())
+}
+```
+
+- [ ] **Step 5: Run tests and clippy**
+
+```
+cargo test --workspace
+cargo clippy --workspace -- -D warnings
+```
+
+Expected: all tests pass, zero warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cel-parser/src/lib.rs cel-parser/src/op_table.rs
+git commit -m "feat: short-circuit && using new_fragment and join2"
+```
+
+---
+
+### Task 2: Short-circuit `||`
+
+**Files:**
+- Modify: `cel-parser/src/lib.rs` — rewrite `is_or_expression`
+- Modify: `cel-parser/src/op_table.rs` — remove `LOGICAL_OR_SIGNATURES` and its `BUILTINS` entry
+
+**Interfaces:**
+- Produces: `is_or_expression(&mut self) -> Result<bool>` — same signature, short-circuits when LHS is `true`
+
+- [ ] **Step 1: Write failing tests**
+
+Add inside `mod tests` in `cel-parser/src/lib.rs`:
+
+```rust
+#[test]
+fn or_short_circuits_on_true() {
+    // Without short-circuit the RHS executes and division-by-zero errors.
+    // With short-circuit the RHS fragment is skipped, returning true directly.
+    let mut parser = CELParser::new(OpLookup::new());
+    let mut segment = parser
+        .parse_str("true || (1i32 / 0i32 == 0i32)")
+        .expect("should parse");
+    assert_eq!(segment.call0::<bool>().unwrap(), true);
+}
+
+#[test]
+fn or_evaluates_rhs_when_lhs_false() {
+    let mut parser = CELParser::new(OpLookup::new());
+    let mut segment = parser
+        .parse_str("false || true")
+        .expect("should parse");
+    assert_eq!(segment.call0::<bool>().unwrap(), true);
+}
+
+#[test]
+fn or_chained() {
+    let mut parser = CELParser::new(OpLookup::new());
+    let mut segment = parser
+        .parse_str("true || false || false")
+        .expect("should parse");
+    assert_eq!(segment.call0::<bool>().unwrap(), true);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+cargo test --workspace or_short_circuits_on_true
+```
+
+Expected: FAIL — errors with division-by-zero instead of returning `Ok(true)`.
+
+- [ ] **Step 3: Rewrite `is_or_expression` in `cel-parser/src/lib.rs`**
+
+Find and replace the entire `is_or_expression` function. The new version removes `start_span` and replaces the `op_lookup.lookup` call. Note the argument order to `join2`: `bypass_fragment` (the `true` shortcut) is fragment_0 (the true-branch), `rhs_fragment` is fragment_1 (the false-branch).
+
+```rust
+/// `or_expression = and_expression { "||" and_expression }.`
+fn is_or_expression(&mut self) -> Result<bool> {
+    if self.is_and_expression()? {
+        while self.is_punctuation("||") {
+            let mut rhs_fragment = self.context.new_fragment();
+            std::mem::swap(&mut self.context, &mut rhs_fragment);
+            if !self.is_and_expression()? {
+                return Err(self.error_at("expected and_expression"));
+            }
+            std::mem::swap(&mut self.context, &mut rhs_fragment);
+            let mut bypass_fragment = self.context.new_fragment();
+            bypass_fragment.just(true);
+            self.context.join2(bypass_fragment, rhs_fragment)?;
+        }
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+```
+
+- [ ] **Step 4: Remove `||` from `cel-parser/src/op_table.rs`**
+
+Remove the static array (including its comment):
+
+```rust
+// Logical OR signatures
+static LOGICAL_OR_SIGNATURES: &[OpSignature] =
+    &[sig!(TYPE_BOOL, 2, |seg| seg.op2(|a: bool, b: bool| a || b))];
+```
+
+Remove its entry from the `BUILTINS` phf map:
+
+```rust
+    "||" => LOGICAL_OR_SIGNATURES,
+```
+
+There is no `test_logical_or` in op_table — no additional test removal needed.
+
+- [ ] **Step 5: Run tests and clippy**
+
+```
+cargo test --workspace
+cargo clippy --workspace -- -D warnings
+```
+
+Expected: all tests pass, zero warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cel-parser/src/lib.rs cel-parser/src/op_table.rs
+git commit -m "feat: short-circuit || using new_fragment and join2"
+```
+
+---
+
+### Task 3: `if`/`else`/`else if` expression
+
+**Files:**
+- Modify: `cel-parser/src/lib.rs` — add `is_keyword`, `is_if_expression`; extend `is_primary_expression`; update module-level grammar comment
+
+**Interfaces:**
+- Produces:
+  - `is_keyword(&mut self, keyword: &str) -> bool` — helper, consumes matching identifier
+  - `is_if_expression(&mut self) -> Result<bool>` — called after `if` is already consumed
+
+- [ ] **Step 1: Write failing tests**
+
+Add inside `mod tests` in `cel-parser/src/lib.rs`:
+
+```rust
+#[test]
+fn if_true_branch_selected() {
+    let mut parser = CELParser::new(OpLookup::new());
+    let mut segment = parser
+        .parse_str("if true { 1i32 } else { 2i32 }")
+        .expect("should parse");
+    assert_eq!(segment.call0::<i32>().unwrap(), 1);
+}
+
+#[test]
+fn if_false_branch_selected() {
+    let mut parser = CELParser::new(OpLookup::new());
+    let mut segment = parser
+        .parse_str("if false { 1i32 } else { 2i32 }")
+        .expect("should parse");
+    assert_eq!(segment.call0::<i32>().unwrap(), 2);
+}
+
+#[test]
+fn if_else_if_first_branch() {
+    let mut parser = CELParser::new(OpLookup::new());
+    let mut segment = parser
+        .parse_str("if true { 1i32 } else if false { 2i32 } else { 3i32 }")
+        .expect("should parse");
+    assert_eq!(segment.call0::<i32>().unwrap(), 1);
+}
+
+#[test]
+fn if_else_if_middle_branch() {
+    let mut parser = CELParser::new(OpLookup::new());
+    let mut segment = parser
+        .parse_str("if false { 1i32 } else if true { 2i32 } else { 3i32 }")
+        .expect("should parse");
+    assert_eq!(segment.call0::<i32>().unwrap(), 2);
+}
+
+#[test]
+fn if_else_if_last_branch() {
+    let mut parser = CELParser::new(OpLookup::new());
+    let mut segment = parser
+        .parse_str("if false { 1i32 } else if false { 2i32 } else { 3i32 }")
+        .expect("should parse");
+    assert_eq!(segment.call0::<i32>().unwrap(), 3);
+}
+
+#[test]
+fn if_omitted_else_unit_branch() {
+    let mut parser = CELParser::new(OpLookup::new());
+    let mut segment = parser
+        .parse_str("if true { () }")
+        .expect("should parse");
+    segment.call0::<()>().expect("should execute");
+}
+
+#[test]
+fn if_omitted_else_rejects_non_unit_then() {
+    // then-branch returns i32, implicit else returns () — types must match.
+    let mut parser = CELParser::new(OpLookup::new());
+    assert!(parser.parse_str("if false { 1i32 }").is_err());
+}
+
+#[test]
+fn if_branch_type_mismatch_is_error() {
+    let mut parser = CELParser::new(OpLookup::new());
+    assert!(parser.parse_str("if true { 1i32 } else { true }").is_err());
+}
+
+#[test]
+fn if_missing_open_brace_is_error() {
+    let mut parser = CELParser::new(OpLookup::new());
+    assert!(parser.parse_str("if true 1i32 } else { 2i32 }").is_err());
+}
+
+#[test]
+fn if_missing_else_after_brace_is_fine() {
+    // Omitting else is allowed; result type must be ().
+    let mut parser = CELParser::new(OpLookup::new());
+    let mut segment = parser
+        .parse_str("if false { () }")
+        .expect("should parse");
+    segment.call0::<()>().expect("should execute");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```
+cargo test --workspace if_true_branch_selected if_false_branch_selected
+```
+
+Expected: FAIL — parse errors because `if` is treated as an unknown identifier.
+
+- [ ] **Step 3: Support `()` as a unit expression in `is_primary_expression`**
+
+In `cel-parser/src/lib.rs`, find the `OpenDelim { Parenthesis }` arm of `is_primary_expression`. It currently reads:
+
+```rust
+Some(Token::OpenDelim {
+    delimiter: Delimiter::Parenthesis,
+    ..
+}) => {
+    self.advance();
+    if !self.is_or_expression()? {
+        return Err(self.error_at("expected expression"));
+    }
+    match self.peek_token() {
+        Some(Token::CloseDelim {
+            delimiter: Delimiter::Parenthesis,
+            ..
+        }) => {
+            self.advance(); // consume CloseDelim
+            Ok(true)
+        }
+        _ => Err(self.error_at("expected closing parenthesis")),
+    }
+}
+```
+
+Replace it with:
+
+```rust
+Some(Token::OpenDelim {
+    delimiter: Delimiter::Parenthesis,
+    ..
+}) => {
+    self.advance();
+    // Unit expression: ()
+    if matches!(
+        self.peek_token(),
+        Some(Token::CloseDelim {
+            delimiter: Delimiter::Parenthesis,
+            ..
+        })
+    ) {
+        self.advance();
+        self.context.just(());
+        return Ok(true);
+    }
+    if !self.is_or_expression()? {
+        return Err(self.error_at("expected expression"));
+    }
+    match self.peek_token() {
+        Some(Token::CloseDelim {
+            delimiter: Delimiter::Parenthesis,
+            ..
+        }) => {
+            self.advance();
+            Ok(true)
+        }
+        _ => Err(self.error_at("expected closing parenthesis")),
+    }
+}
+```
+
+- [ ] **Step 4: Add `is_keyword` helper to `CELParser` in `cel-parser/src/lib.rs`**
+
+Add this method to the `impl CELParser` block, adjacent to `is_punctuation`:
+
+```rust
+/// Consumes and returns `true` if the next token is an identifier matching `keyword`.
+fn is_keyword(&mut self, keyword: &str) -> bool {
+    match self.peek_token() {
+        Some(Token::Identifier(ident)) if ident.to_string() == keyword => {
+            self.advance();
+            true
+        }
+        _ => false,
+    }
+}
+```
+
+- [ ] **Step 5: Add `is_if_expression` method to `CELParser` in `cel-parser/src/lib.rs`**
+
+Add this method to the `impl CELParser` block. Place it after `is_primary_expression`:
+
+```rust
+/// `if_expression = "if" or_expression "{" or_expression "}" [ "else" ( "{" or_expression "}" | if_expression ) ].`
+///
+/// - Precondition: The `if` keyword has already been consumed by the caller.
+fn is_if_expression(&mut self) -> Result<bool> {
+    if !self.is_or_expression()? {
+        return Err(self.error_at("expected condition after `if`"));
+    }
+    match self.peek_token() {
+        Some(Token::OpenDelim {
+            delimiter: Delimiter::Brace,
+            ..
+        }) => {
+            self.advance();
+        }
+        _ => return Err(self.error_at("expected `{` after if condition")),
+    }
+    let mut then_fragment = self.context.new_fragment();
+    std::mem::swap(&mut self.context, &mut then_fragment);
+    if !self.is_or_expression()? {
+        return Err(self.error_at("expected expression in then-branch"));
+    }
+    std::mem::swap(&mut self.context, &mut then_fragment);
+    match self.peek_token() {
+        Some(Token::CloseDelim {
+            delimiter: Delimiter::Brace,
+            ..
+        }) => {
+            self.advance();
+        }
+        _ => return Err(self.error_at("expected `}` after then-branch")),
+    }
+    let else_fragment = if self.is_keyword("else") {
+        if self.is_keyword("if") {
+            // else if: recursively parse another if_expression
+            let mut fragment = self.context.new_fragment();
+            std::mem::swap(&mut self.context, &mut fragment);
+            self.is_if_expression()?;
+            std::mem::swap(&mut self.context, &mut fragment);
+            fragment
+        } else {
+            // else { expr }
+            match self.peek_token() {
+                Some(Token::OpenDelim {
+                    delimiter: Delimiter::Brace,
+                    ..
+                }) => {
+                    self.advance();
+                }
+                _ => return Err(self.error_at("expected `{` or `if` after `else`")),
+            }
+            let mut fragment = self.context.new_fragment();
+            std::mem::swap(&mut self.context, &mut fragment);
+            if !self.is_or_expression()? {
+                return Err(self.error_at("expected expression in else-branch"));
+            }
+            std::mem::swap(&mut self.context, &mut fragment);
+            match self.peek_token() {
+                Some(Token::CloseDelim {
+                    delimiter: Delimiter::Brace,
+                    ..
+                }) => {
+                    self.advance();
+                }
+                _ => return Err(self.error_at("expected `}` after else-branch")),
+            }
+            fragment
+        }
+    } else {
+        // Implicit else: () — then-branch must also return ()
+        let mut fragment = self.context.new_fragment();
+        fragment.just(());
+        fragment
+    };
+    self.context.join2(then_fragment, else_fragment)?;
+    Ok(true)
+}
+```
+
+- [ ] **Step 6: Extend `is_primary_expression` to dispatch `"if"` to `is_if_expression`**
+
+In `cel-parser/src/lib.rs`, find the `Token::Identifier(ident)` arm of `is_primary_expression`. It currently reads:
+
+```rust
+Some(Token::Identifier(ident)) => {
+    let ident_name = ident.to_string();
+    let ident_span = ident.span();
+    self.advance();
+
+    self.op_lookup
+        .lookup(&ident_name, &mut self.context, 0, ident_span, ident_span)?;
+
+    Ok(true)
+}
+```
+
+Replace it with:
+
+```rust
+Some(Token::Identifier(ident)) => {
+    let ident_name = ident.to_string();
+    let ident_span = ident.span();
+    self.advance();
+
+    if ident_name == "if" {
+        return self.is_if_expression();
+    }
+
+    self.op_lookup
+        .lookup(&ident_name, &mut self.context, 0, ident_span, ident_span)?;
+
+    Ok(true)
+}
+```
+
+- [ ] **Step 7: Update the module-level grammar comment in `cel-parser/src/lib.rs`**
+
+Find the `//! primary_expression = ...` line in the module doc comment (around line 29) and replace it with:
+
+```rust
+//! primary_expression = literal | identifier | "(" or_expression ")" | if_expression.
+//! if_expression = "if" or_expression "{" or_expression "}" [ "else" ( "{" or_expression "}" | if_expression ) ].
+```
+
+- [ ] **Step 8: Run all tests and clippy**
+
+```
+cargo test --workspace
+cargo clippy --workspace -- -D warnings
+```
+
+Expected: all tests pass, zero warnings.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add cel-parser/src/lib.rs
+git commit -m "feat: add if/else/else-if expression with optional else"
+```

--- a/docs/superpowers/specs/2026-06-19-if-and-short-circuit-design.md
+++ b/docs/superpowers/specs/2026-06-19-if-and-short-circuit-design.md
@@ -1,0 +1,158 @@
+# Design: `if` Expression and Short-Circuit `&&`/`||`
+
+**Date:** 2026-06-19  
+**Branch:** `sean-parent/if-and-short-circuit`
+
+## Summary
+
+Add `if`/`else`/`else if` expression support to the CEL parser and fix `&&`/`||` to short-circuit. Both features use `DynSegment::new_fragment()` and `DynSegment::join2()` — the existing conditional-execution primitive — rather than any new runtime infrastructure.
+
+## Approach
+
+Context-swap in the parser. When a branch expression needs lazy evaluation, the parser:
+
+1. Creates a fragment: `let mut fragment = self.context.new_fragment()`
+2. Swaps it into place: `std::mem::swap(&mut self.context, &mut fragment)`
+3. Parses the sub-expression (ops land in the fragment)
+4. Swaps back: `std::mem::swap(&mut self.context, &mut fragment)`
+5. Calls `self.context.join2(then_fragment, else_fragment)`
+
+`join2` pops a `bool` from the main stack, executes one of the two fragments, and pushes the result. Both fragments must return exactly one value of the same type.
+
+## Grammar
+
+```
+expression        = or_expression
+or_expression     = and_expression { "||" and_expression }
+and_expression    = comparison_expression { "&&" comparison_expression }
+...
+primary_expression = literal
+                   | identifier
+                   | "(" or_expression ")"
+                   | if_expression
+
+if_expression = "if" or_expression "{" or_expression "}" [ else_clause ]
+else_clause   = "else" ( "{" or_expression "}" | if_expression )
+```
+
+`if` is recognized as a keyword inside the `Identifier` arm of `is_primary_expression` (checked before `op_lookup` dispatch). `else` is consumed explicitly by the `if` handler and never reaches `op_lookup`.
+
+## Short-Circuit `&&` and `||`
+
+### `&&`
+
+`is_and_expression` in `cel-parser/src/lib.rs` replaces the `op_lookup.lookup("&&", ...)` call with:
+
+```
+parse LHS → context stack: [bool]
+rhs_fragment   = context.new_fragment(); parse RHS into it → [bool]
+bypass_fragment = context.new_fragment(); bypass.just(false)
+context.join2(rhs_fragment, bypass_fragment)
+  // condition true  → execute rhs_fragment  (result = RHS value)
+  // condition false → execute bypass_fragment (result = false, RHS skipped)
+```
+
+### `||`
+
+`is_or_expression` replaces the `op_lookup.lookup("||", ...)` call with:
+
+```
+parse LHS → context stack: [bool]
+rhs_fragment    = context.new_fragment(); parse RHS into it → [bool]
+bypass_fragment = context.new_fragment(); bypass.just(true)
+context.join2(bypass_fragment, rhs_fragment)
+  // condition true  → execute bypass_fragment (result = true, RHS skipped)
+  // condition false → execute rhs_fragment    (result = RHS value)
+```
+
+### Op-table cleanup
+
+`LOGICAL_AND_SIGNATURES`, `LOGICAL_OR_SIGNATURES`, and their entries in the `OP_TABLE` phf map are removed from `cel-parser/src/op_table.rs`. Type checking is still enforced: `join2` verifies the stack top is `bool` and both fragments return the same type.
+
+The `test_logical_and` test in `op_table.rs` is removed; coverage moves to parser-level tests.
+
+## `if` Expression
+
+`is_if_expression` is extracted as its own method and called from `is_primary_expression` when the identifier `"if"` is encountered.
+
+### Parsing steps
+
+1. Consume `"if"` identifier
+2. Parse condition with `is_or_expression` — stops naturally at `{` (an `OpenDelim` matches no binary-op continuation)
+3. Expect and consume `OpenDelim(Brace)`; error: `"expected '{' after if condition"`
+4. Context-swap → parse then-branch with `is_or_expression` → swap back → `then_fragment`; error if empty: `"expected expression in then-branch"`
+5. Expect and consume `CloseDelim(Brace)`; error: `"expected '}' after then-branch"`
+6. Check for `Identifier("else")`:
+   - **Present:** consume `"else"`, then:
+     - `OpenDelim(Brace)` → context-swap → parse `is_or_expression` → swap back → `else_fragment`; consume `CloseDelim(Brace)`
+     - `Identifier("if")` → call `is_if_expression` recursively; result becomes `else_fragment`
+     - Anything else → error: `"expected '{' or 'if' after else"`
+   - **Absent:** `else_fragment` = `context.new_fragment()` with `op0(|| ())`
+7. `context.join2(then_fragment, else_fragment)`
+
+### Optional `else`
+
+When `else` is omitted, `else_fragment` pushes `()`. The `then_fragment` must also return `()` — `join2` enforces matching types and will error (`"fragment result types must match"`) if the then-branch produces a non-unit value.
+
+### Type checking
+
+`join2` already enforces:
+- Condition on stack is `bool`
+- Both fragments return exactly one value
+- Both fragment result types match
+
+No additional type-checking code is needed.
+
+## Error Messages
+
+| Situation | Message |
+|-----------|---------|
+| `&&`/`\|\|` RHS missing | `"expected comparison_expression"` / `"expected and_expression"` (unchanged) |
+| `&&`/`\|\|` RHS wrong type | `"fragment result types must match"` (from `join2`) |
+| Missing `{` after condition | `"expected '{' after if condition"` |
+| Empty then-branch | `"expected expression in then-branch"` |
+| Missing `}` after then-branch | `"expected '}' after then-branch"` |
+| Missing `else` keyword when required | n/a — `else` is optional |
+| Missing `{` or `if` after `else` | `"expected '{' or 'if' after else"` |
+| Empty else-branch | `"expected expression in else-branch"` |
+| Missing `}` after else-branch | `"expected '}' after else-branch"` |
+| Branch type mismatch | `"fragment result types must match"` (from `join2`) |
+| `if` without else, non-unit then | `"fragment result types must match"` (from `join2`) |
+
+## Tests
+
+All tests verify observable behavior from the contract (not implementation internals).
+
+### Short-circuit tests (in `cel-parser/src/lib.rs`)
+
+- `false && expr` returns `false` even when `expr` would error at runtime (short-circuit)
+- `true || expr` returns `true` even when `expr` would error at runtime (short-circuit)
+- `true && false` → `false`
+- `false || true` → `true`
+- Chained: `false && false && false` → `false`
+- Chained: `true || false || false` → `true`
+- Type error: `1i32 && true` → parse error (LHS not `bool`)
+
+### `if` expression tests (in `cel-parser/src/lib.rs`)
+
+- `if true { 1i32 } else { 2i32 }` → `1`
+- `if false { 1i32 } else { 2i32 }` → `2`
+- `if true { 1i32 } else if false { 2i32 } else { 3i32 }` → `1`
+- `if false { 1i32 } else if false { 2i32 } else { 3i32 }` → `3`
+- `if false { 1i32 } else if true { 2i32 } else { 3i32 }` → `2`
+- `if true { () }` (omitted else) → `()`
+- `if false { 1i32 }` (omitted else, type mismatch) → parse error
+- `if true { 1i32 } else { true }` (branch type mismatch) → parse error
+- `if true { 1i32 }` missing `{` → parse error with `"expected '{' after if condition"`
+- `if true { 1i32 } else` trailing `else` → parse error
+
+### Op-table tests
+
+- `test_logical_and` in `op_table.rs` is removed; `&&`/`||` no longer dispatched through op-table
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `cel-parser/src/lib.rs` | Rewrite `is_and_expression`, `is_or_expression`; add `is_if_expression`; extend `is_primary_expression` |
+| `cel-parser/src/op_table.rs` | Remove `LOGICAL_AND_SIGNATURES`, `LOGICAL_OR_SIGNATURES`, their `OP_TABLE` entries, and `test_logical_and` |


### PR DESCRIPTION
## Summary

- Replace eager `&&`/`||` dispatch (op-table) with `new_fragment()` + `join2()` so the RHS is only evaluated when needed (genuine short-circuit)
- Add `if`/`else`/`else-if` expression support with Rust-style brace syntax; `else` is optional (implicit `else { () }`)
- Remove `LOGICAL_AND_SIGNATURES` and `LOGICAL_OR_SIGNATURES` from `op_table.rs`; type checking is enforced by `join2` instead

All three features share the same **context-swap pattern**: before parsing a lazy sub-expression the parser swaps a fresh fragment into `self.context`, parses into it, swaps back, then calls `join2(then_fragment, else_fragment)`.

`CELParser` doc updated with the general discard-on-error contract: if a mutating operation returns `Err`, the parser is in an unspecified state and must be discarded.

## Grammar added

```
if_expression = "if" or_expression "{" or_expression "}" [ else_clause ]
else_clause   = "else" ( "{" or_expression "}" | if_expression )
```

## Test plan

- [x] Short-circuit: `false && <error-expr>` returns `false` without evaluating RHS
- [x] Short-circuit: `true || <error-expr>` returns `true` without evaluating RHS
- [x] `if true { 1i32 } else { 2i32 }` → `1`; `if false { ... }` → `2`
- [x] `else if` chaining (3-way branch)
- [x] Omitted `else` with unit then-branch → `()`
- [x] Omitted `else` with non-unit then-branch → parse error (type mismatch)
- [x] Branch type mismatch → parse error
- [x] LHS type errors for both `&&` and `||` → parse error
- [x] Missing `{`/`}` and trailing `else` → parse errors
- [x] All 181 tests pass; `cargo clippy --workspace -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core boolean evaluation semantics (short-circuit) and extends the expression grammar; behavior is heavily tested but any consumer relying on eager `&&`/`||` would see different runtime errors.
> 
> **Overview**
> Adds **Rust-style `if` / `else` / `else if` expressions** and changes **`&&` and `||` to short-circuit** at evaluation time instead of always running both sides.
> 
> Logical `&&` / `||` are no longer dispatched through the op table. The parser builds lazy RHS fragments with `new_fragment()`, swaps parse context, and wires branches with **`join2`** so only the taken branch runs (e.g. `false && (1i32 / 0i32 …)` returns `false` without dividing by zero). **`LOGICAL_AND_SIGNATURES` / `LOGICAL_OR_SIGNATURES`** and their builtin map entries are removed; bool typing for these operators comes from **`join2`**.
> 
> **`if`** is parsed as a keyword in `primary_expression`: condition, braced then-branch, optional `else` / `else if`, with **`join2`** merging branches and enforcing matching result types. Omitted **`else`** implies unit **`()`** on the false branch (then-branch must also be unit). Empty **`()`** is now a valid primary expression.
> 
> Repo hygiene: a **pre-commit hook** runs **`cargo fmt --all --check`**, with **`CLAUDE.md`** documenting hook setup and format commands. Design/plan docs under **`docs/superpowers/`** describe the approach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1643ea710d720ea98442490cf79cd0916dbddf99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->